### PR TITLE
fixed undefined symbol on linux and macOS

### DIFF
--- a/.github/workflows/libserum.yml
+++ b/.github/workflows/libserum.yml
@@ -40,9 +40,9 @@ jobs:
         run: |
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             if [[ "${{ matrix.platform-name }}" == "Win32" ]]; then
-              cmake -G "Visual Studio 17 2022" -A ${{ matrix.platform-name }} -B build -DUSE_WIN32=ON -DUSE_DLLEXPORTS=ON
+              cmake -G "Visual Studio 17 2022" -A ${{ matrix.platform-name }} -B build -DUSE_WIN32=ON
             else
-              cmake -G "Visual Studio 17 2022" -A ${{ matrix.platform-name }} -B build -DUSE_DLLEXPORTS=ON
+              cmake -G "Visual Studio 17 2022" -A ${{ matrix.platform-name }} -B build
             fi
             cmake --build build --config Release
           else

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,6 @@ project(serum VERSION 1.0.1 DESCRIPTION
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_C_STANDARD 99)
 
-option(USE_DLLEXPORTS "dll exports" OFF)
-if (USE_DLLEXPORTS)
-    add_compile_definitions(DLL_EXPORTS)
-endif()
-
 option(USE_WIN32 "Win32" OFF)
 if (USE_WIN32)
     add_compile_definitions(WIN32)

--- a/src/serum-decode.h
+++ b/src/serum-decode.h
@@ -1,18 +1,10 @@
 #ifndef SERUM_DECODE_H
 #define SERUM_DECODE_H
 
-#if defined DLL_EXPORTS
-  #if defined WIN32
-    #define SERUM_API(RetType) extern "C" __declspec(dllexport) RetType
-  #else
-    #define SERUM_API(RetType) extern "C" RetType __attribute__((visibility("default")))
-  #endif
+#if defined WIN32
+#define SERUM_API(RetType) extern "C" __declspec(dllexport) RetType
 #else
-  #if defined WIN32
-    #define SERUM_API(RetType) extern "C" __declspec(dllimport) RetType
-  #else
-    #define SERUM_API(RetType) extern "C" RetType
-  #endif
+#define SERUM_API(RetType) extern "C" RetType __attribute__((visibility("default")))
 #endif
 
 #define MIN(a,b) ((a) < (b) ? (a) : (b))


### PR DESCRIPTION
Undefined symbols for architecture x86_64:
  "_Serum_Load", referenced from:
      _main in ppuc.cpp.o
ld: symbol(s) not found for architecture x86_64
