### PR TITLE
ci: rework ci to build ios and android. add static libs

### DIFF
--- a/.github/workflows/libserum.yml
+++ b/.github/workflows/libserum.yml
@@ -17,23 +17,21 @@ jobs:
           - os: windows-latest
             platform: win-x64
             platform-name: x64
-            libserum: serum.dll
           - os: windows-latest
             platform: win-x86
             platform-name: Win32
-            libserum: serum.dll
           - os: macos-latest
             platform: macOS-x64
-            libserum: libserum.dylib
           - os: macos-latest
             platform: macOS-arm64
-            libserum: libserum.dylib
+          - os: macos-latest
+            platform: ios-arm64
+          - os: macos-latest
+            platform: tvos-arm64
           - os: ubuntu-latest
             platform: linux-x64
-            libserum: libserum.so
           - os: ubuntu-latest
             platform: android-arm64-v8a
-            libserum: libserum.so
     steps:
       - uses: actions/checkout@v3
       - name: Build libserum-${{ matrix.platform }}
@@ -45,13 +43,20 @@ jobs:
               cmake -G "Visual Studio 17 2022" -A ${{ matrix.platform-name }} -B build
             fi
             cmake --build build --config Release
-          else
-            if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-              if [[ "${{ matrix.platform }}" == "macOS-arm64" ]]; then
-                cmake -DCMAKE_BUILD_TYPE=Release -B build/Release -DUSE_OSXARM=ON
-              else
-                cmake -DCMAKE_BUILD_TYPE=Release -B build/Release -DUSE_OSXINTEL=ON
-              fi
+          elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            if [[ "${{ matrix.platform }}" == "macOS-arm64" ]]; then
+              cmake -DCMAKE_BUILD_TYPE=Release -B build/Release -DUSE_OSXARM=ON
+            elif [[ "${{ matrix.platform }}" == "macOS-x64" ]]; then
+              cmake -DCMAKE_BUILD_TYPE=Release -B build/Release -DUSE_OSXINTEL=ON
+            elif  [[ "${{ matrix.platform }}" == "ios-arm64" ]]; then
+              cmake -DCMAKE_BUILD_TYPE=Release -B build/Release -DUSE_IOS=ON
+            elif  [[ "${{ matrix.platform }}" == "tvos-arm64" ]]; then
+              cmake -DCMAKE_BUILD_TYPE=Release -B build/Release -DUSE_TVOS=ON
+            fi
+            cmake --build build/Release
+          elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            if [[ "${{ matrix.platform }}" == "android-arm64-v8a" ]]; then
+              cmake -DCMAKE_BUILD_TYPE=Release -B build/Release -DUSE_ANDROID=ON
             else
               cmake -DCMAKE_BUILD_TYPE=Release -B build/Release
             fi
@@ -59,7 +64,11 @@ jobs:
           fi
       - run: |
           mkdir tmp
-          cp build/Release/${{ matrix.libserum }} tmp
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+             cp build/Release/serum* tmp
+          else
+             cp build/Release/libserum* tmp
+          fi
       - uses: actions/upload-artifact@v3
         with:
           name: libserum-${{ matrix.platform }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,42 +1,80 @@
-cmake_minimum_required(VERSION 3.9)
-
-project(serum VERSION 1.1 DESCRIPTION
-        "Cross-platform library for decoding Serum files, a colorization format for pinball ROMs.")
-
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_C_STANDARD 99)
-
-option(USE_WIN32 "Win32" OFF)
-if (USE_WIN32)
-    add_compile_definitions(WIN32)
-endif()
+cmake_minimum_required(VERSION 3.18)
 
 option(USE_OSXARM "macOS arm64" OFF)
-if (USE_OSXARM)
-    set(CMAKE_OSX_ARCHITECTURES arm64)
-endif()
-
 option(USE_OSXINTEL "macOS x86_64" OFF)
-if (USE_OSXINTEL)
-    set(CMAKE_OSX_ARCHITECTURES x86_64)
+option(USE_IOS "ios" OFF)
+option(USE_TVOS "tvos" OFF)
+option(USE_ANDROID "android" OFF)
+option(USE_WIN32 "Win32" OFF)
+
+if(USE_IOS)
+   set(CMAKE_SYSTEM_NAME iOS)
+elseif(USE_TVOS)
+   set(CMAKE_SYSTEM_NAME tvOS)
+elseif(USE_ANDROID)
+   set(CMAKE_SYSTEM_NAME Android)
+   set(CMAKE_SYSTEM_VERSION 30)
+   set(CMAKE_ANDROID_ARCH_ABI arm64-v8a)
 endif()
 
-add_library(serum SHARED
-        src/miniz/miniz.h
-        src/miniz/miniz.c
-        src/serum-decode.h
-        src/serum-decode.cpp
-        )
+project(serum VERSION 1.1.1
+	DESCRIPTION "Cross-platform library for decoding Serum files, a colorization format for pinball ROMs.")
 
-set_target_properties(serum PROPERTIES
-        VERSION ${PROJECT_VERSION}
-        SOVERSION 1
-        )
+string(REGEX MATCH "^[0-9]+" SERUM_VERSION_MAJOR "${PROJECT_VERSION}")
+string(REGEX MATCH "[0-9]+$" SERUM_VERSION_PATCH "${PROJECT_VERSION}")
+string(REGEX MATCH "\\.[0-9]+" SERUM_VERSION_MINOR "${PROJECT_VERSION}")
+string(REPLACE "." "" SERUM_VERSION_MINOR "${SERUM_VERSION_MINOR}")
 
-target_include_directories(serum PUBLIC
-        src
-        )
+if(USE_OSXARM)
+   set(CMAKE_OSX_ARCHITECTURES arm64)
+elseif(USE_OSXINTEL)
+   set(CMAKE_OSX_ARCHITECTURES x86_64)
+elseif(USE_IOS OR USE_TVOS)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET 16.0)
+  set(CMAKE_OSX_ARCHITECTURES arm64)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+  set(CMAKE_C_FLAGS -fembed-bitcode)
+  set(CMAKE_CXX_FLAGS -fembed-bitcode)
+endif()
 
-install(TARGETS serum
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+
+if(USE_WIN32)
+   add_compile_definitions(WIN32)
+endif()
+
+set(LIBRARY_SOURCES
+   src/miniz/miniz.h
+   src/miniz/miniz.c
+   src/serum-decode.h
+   src/serum-decode.cpp
+)
+
+set(INCLUDE_DIRS
+   src
+)
+
+if(NOT USE_IOS AND NOT USE_TVOS)
+   add_library(serum_shared SHARED ${LIBRARY_SOURCES})
+   set_target_properties(serum_shared PROPERTIES
+      OUTPUT_NAME "serum"
+      VERSION ${SERUM_VERSION_MAJOR}.${SERUM_VERSION_MINOR}.${SERUM_VERSION_PATCH}
+      LINK_FLAGS_RELEASE -s
+   )
+   target_include_directories(serum_shared PUBLIC ${INCLUDE_DIRS})
+   install(TARGETS serum_shared
+      LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+   )
+endif()
+
+add_library(serum_static STATIC ${LIBRARY_SOURCES})
+set_target_properties(serum_static PROPERTIES OUTPUT_NAME "serum")
+target_include_directories(serum_static PUBLIC ${INCLUDE_DIRS})
+install(TARGETS serum_static
+   LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+)
+
+install(FILES src/serum-decode.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -5,6 +5,10 @@
 #include <string.h>
 #include <miniz/miniz.h>
 
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
 #pragma warning(disable: 4996)
 
 const char dllversion[] = "1.3";
@@ -236,7 +240,14 @@ SERUM_API(bool) Serum_Load(const char* const altcolorpath, const char* const rom
     if ((tbuf[strlen(tbuf) - 1] != '\\') && (tbuf[strlen(tbuf) - 1] != '/')) strcat(tbuf, "/");
     strcat(tbuf, romname);
     strcat(tbuf, "/");
+
+#if !(defined(__APPLE__) && ((defined(TARGET_OS_IOS) && TARGET_OS_IOS) || (defined(TARGET_OS_TV) && TARGET_OS_TV)))
     strcpy(tbuf2, tbuf);
+#else
+    strcpy(tbuf2, getenv("TMPDIR"));
+    strcat(tbuf2, "/");
+#endif
+
     strcat(tbuf, romname);
     strcat(tbuf, ".cRZ");
     char cromname[260];


### PR DESCRIPTION
This PR makes static and shared libs. It also adds support for iOS, tvOS, and Android builds. 

Note on iOS and tvOS, we extract to `TMPDIR` env since we can't extract back to the resource folder.