### PR TITLE
Allow CMakeLists.txt to be used as a library in other CMake projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,8 @@ set(INCLUDE_DIRS
    src
 )
 
+include_directories(AFTER src)
+
 if(NOT USE_IOS AND NOT USE_TVOS)
    add_library(serum_shared SHARED ${LIBRARY_SOURCES})
    set_target_properties(serum_shared PROPERTIES
@@ -70,11 +72,13 @@ if(NOT USE_IOS AND NOT USE_TVOS)
    )
 endif()
 
-add_library(serum_static STATIC ${LIBRARY_SOURCES})
-set_target_properties(serum_static PROPERTIES OUTPUT_NAME "serum")
-target_include_directories(serum_static PUBLIC ${INCLUDE_DIRS})
-install(TARGETS serum_static
-   LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-)
 
-install(FILES src/serum-decode.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    add_library(serum_static STATIC ${LIBRARY_SOURCES})
+    set_target_properties(serum_static PROPERTIES OUTPUT_NAME "serum")
+    target_include_directories(serum_static PUBLIC ${INCLUDE_DIRS})
+    install(TARGETS serum_static
+       LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+    )
+    install(FILES src/serum-decode.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,26 +59,32 @@ set(INCLUDE_DIRS
 
 include_directories(AFTER src)
 
-if(NOT USE_IOS AND NOT USE_TVOS)
-   add_library(serum_shared SHARED ${LIBRARY_SOURCES})
-   set_target_properties(serum_shared PROPERTIES
-      OUTPUT_NAME "serum"
-      VERSION ${SERUM_VERSION_MAJOR}.${SERUM_VERSION_MINOR}.${SERUM_VERSION_PATCH}
-      LINK_FLAGS_RELEASE -s
-   )
-   target_include_directories(serum_shared PUBLIC ${INCLUDE_DIRS})
-   install(TARGETS serum_shared
-      LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-   )
-endif()
-
-
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-    add_library(serum_static STATIC ${LIBRARY_SOURCES})
-    set_target_properties(serum_static PROPERTIES OUTPUT_NAME "serum")
-    target_include_directories(serum_static PUBLIC ${INCLUDE_DIRS})
-    install(TARGETS serum_static
-       LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-    )
-    install(FILES src/serum-decode.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+    if(NOT USE_IOS AND NOT USE_TVOS)
+       add_library(serum_shared SHARED ${LIBRARY_SOURCES})
+       set_target_properties(serum_shared PROPERTIES
+          OUTPUT_NAME "serum"
+          VERSION ${SERUM_VERSION_MAJOR}.${SERUM_VERSION_MINOR}.${SERUM_VERSION_PATCH}
+          LINK_FLAGS_RELEASE -s
+       )
+       target_include_directories(serum_shared PUBLIC ${INCLUDE_DIRS})
+       install(TARGETS serum_shared
+          LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+       )
+    endif()
+
+
+    if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+        add_library(serum_static STATIC ${LIBRARY_SOURCES})
+        set_target_properties(serum_static PROPERTIES OUTPUT_NAME "serum")
+        target_include_directories(serum_static PUBLIC ${INCLUDE_DIRS})
+        install(TARGETS serum_static
+           LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+        )
+        install(FILES src/serum-decode.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+    endif()
+
+else()
+    include_directories(AFTER src)
+    add_library(Serum ${LIBRARY_SOURCES})
 endif()


### PR DESCRIPTION
libs will be generated only if cmake it called directly for this file, not if it's included as a library from another project

To use it do the following in your CMakeLists.txt:

```
add_subdirectory("external/libserum") // or whatever path it is stored
set (SERUM_LIBRARIES Serum) 
``` 

and add SERUM_LIBRARIES to your target_link_libraries() statement