### PR TITLE
Fixed same frame behaviour, removed obsolete code

### DIFF
--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -1488,9 +1488,10 @@ SERUM_API uint32_t Serum_ColorizeWithMetadatav2(uint8_t* frame)
 			framesSkippedCounter = 0;
 		}
 
-		if (frameID = IDENTIFY_SAME_FRAME) return IDENTIFY_NO_FRAME;
+		if (frameID == IDENTIFY_SAME_FRAME) return IDENTIFY_NO_FRAME;
 
 		mySerum.frameID = frameID;
+		mySerum.rotationtimer = 0;
 
 		uint8_t nosprite[MAX_SPRITES_PER_FRAME], nspr;
 		uint16_t frx[MAX_SPRITES_PER_FRAME], fry[MAX_SPRITES_PER_FRAME], spx[MAX_SPRITES_PER_FRAME], spy[MAX_SPRITES_PER_FRAME], wid[MAX_SPRITES_PER_FRAME], hei[MAX_SPRITES_PER_FRAME];
@@ -1600,7 +1601,6 @@ SERUM_API uint32_t Serum_Colorize(uint8_t* frame)
 	// return IDENTIFY_NO_FRAME if no new frame detected
 	// return 0 if new frame with no rotation detected
 	// return > 0 if new frame with rotations detected, the value is the delay before the first rotation in ms 
-	mySerum.rotationtimer = 0;
 	if (SerumVersion == SERUM_V2) return Serum_ColorizeWithMetadatav2(frame);
 	else return Serum_ColorizeWithMetadatav1(frame);
 }

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -363,7 +363,6 @@ size_t my_fread(void* pBuffer, size_t sizeElement, size_t nElements, FILE* strea
 
 Serum_Frame_Struc* Serum_LoadFilev2(FILE* pfile, const uint8_t flags, bool uncompressedCROM, char* pathbuf)
 {
-	mySerum.SerumVersion = SerumVersion = SERUM_V2;
 	my_fread(&fwidth, 4, 1, pfile);
 	my_fread(&fheight, 4, 1, pfile);
 	my_fread(&fwidthx, 4, 1, pfile);
@@ -571,6 +570,8 @@ Serum_Frame_Struc* Serum_LoadFilev2(FILE* pfile, const uint8_t flags, bool uncom
 		else mySerum.width64 = fwidth;
 	}
 	else mySerum.width64 = 0;
+
+	mySerum.SerumVersion = SerumVersion = SERUM_V2;
 
 	Full_Reset_ColorRotations();
 	cromloaded = true;
@@ -805,6 +806,7 @@ Serum_Frame_Struc* Serum_LoadFilev1(const char* const filename, const uint8_t fl
 
 SERUM_API Serum_Frame_Struc* Serum_Load(const char* const altcolorpath, const char* const romname, uint8_t flags)
 {
+	mySerum.SerumVersion = SerumVersion = 0;
 	mySerum.flags = 0;
 	mySerum.frame = NULL;
 	mySerum.frame32 = NULL;

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -1440,6 +1440,20 @@ uint32_t Serum_ColorizeWithMetadatav1(uint8_t* frame)
 		}
 	}
 
+	uint32_t now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+	if ((ignoreUnknownFramesTimeout && (now - lastframe_found) >= ignoreUnknownFramesTimeout) || (maxFramesToSkip && (frameID == IDENTIFY_NO_FRAME) && (++framesSkippedCounter >= maxFramesToSkip)))
+	{
+		// apply standard palette
+		memcpy(mySerum.palette, standardPalette, standardPaletteLength);
+		// disable render features like rotations
+		for (uint32_t ti = 0; ti < MAX_COLOR_ROTATIONS * 3; ti++)
+		{
+			mySerum.rotations[ti] = 255;
+		}
+		mySerum.rotationtimer = 0;
+		return 0;  // new but not colorized frame, return true
+	}
+
 	return IDENTIFY_NO_FRAME;  // no new frame, return false, client has to update rotations!
 }
 

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -1477,19 +1477,24 @@ SERUM_API uint32_t Serum_ColorizeWithMetadatav2(uint8_t* frame)
 
 	// Let's first identify the incoming frame among the ones we have in the crom
 	uint32_t frameID = Identify_Frame(frame);
-	uint8_t nosprite[MAX_SPRITES_PER_FRAME], nspr;
-	uint16_t frx[MAX_SPRITES_PER_FRAME], fry[MAX_SPRITES_PER_FRAME], spx[MAX_SPRITES_PER_FRAME], spy[MAX_SPRITES_PER_FRAME], wid[MAX_SPRITES_PER_FRAME], hei[MAX_SPRITES_PER_FRAME];
-	memset(nosprite, 255, MAX_SPRITES_PER_FRAME);
+	mySerum.frameID = IDENTIFY_NO_FRAME;
 
 	if (frameID != IDENTIFY_NO_FRAME)
 	{
-		if (frameID != IDENTIFY_SAME_FRAME) mySerum.frameID = frameID;
 		// frame identified
 		lastframe_found = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 		if (maxFramesToSkip)
 		{
 			framesSkippedCounter = 0;
 		}
+
+		if (frameID = IDENTIFY_SAME_FRAME) return IDENTIFY_NO_FRAME;
+
+		mySerum.frameID = frameID;
+
+		uint8_t nosprite[MAX_SPRITES_PER_FRAME], nspr;
+		uint16_t frx[MAX_SPRITES_PER_FRAME], fry[MAX_SPRITES_PER_FRAME], spx[MAX_SPRITES_PER_FRAME], spy[MAX_SPRITES_PER_FRAME], wid[MAX_SPRITES_PER_FRAME], hei[MAX_SPRITES_PER_FRAME];
+		memset(nosprite, 255, MAX_SPRITES_PER_FRAME);
 
 		bool isspr = Check_Sprites(frame, lastfound, nosprite, &nspr, frx, fry, spx, spy, wid, hei);
 		if (((frameID < MAX_NUMBER_FRAMES) || isspr) && activeframes[lastfound] != 0)
@@ -1587,45 +1592,7 @@ SERUM_API uint32_t Serum_ColorizeWithMetadatav2(uint8_t* frame)
 		}
 	}
 	
-
-	// no frame identified from the inbound frame or the frame identified is the same with the same sprites
-	// we resent the previous one
-	mySerum.frameID = IDENTIFY_NO_FRAME;
-	if (mySerum.frame32)
-	{
-		mySerum.width32 = lastwidth32;
-		memcpy(mySerum.frame32, lastframe32, min(fwidth, fwidthx) * 32 * 2);
-		memcpy(mySerum.rotations32, lastrotations32, MAX_LENGTH_COLOR_ROTATION * MAX_COLOR_ROTATIONN);
-		memcpy(mySerum.rotationsinframe32, lastrotationsinframe32, min(fwidth, fwidthx) * 32 * 2 * 2);
-	}
-	if (mySerum.frame64)
-	{
-		mySerum.width64 = lastwidth64;
-		memcpy(mySerum.frame64, lastframe64, max(fwidth, fwidthx) * 64 * 2);
-		memcpy(mySerum.rotations64, lastrotations64, MAX_LENGTH_COLOR_ROTATION * MAX_COLOR_ROTATIONN);
-		memcpy(mySerum.rotationsinframe64, lastrotationsinframe64, max(fwidth, fwidthx) * 64 * 2 * 2);
-	}
-	nspr = lastnsprites;
-	for (uint32_t ti = 0; ti < lastnsprites; ti++)
-	{
-		nosprite[ti] = lastsprite[ti];
-		frx[ti] = lastfrx[ti];
-		fry[ti] = lastfry[ti];
-		spx[ti] = lastspx[ti];
-		spy[ti] = lastspy[ti];
-		wid[ti] = lastwid[ti];
-		hei[ti] = lasthei[ti];
-	}
-
-    for (int ti = 0; ti < MAX_COLOR_ROTATIONN; ti++)
-    {
-        if (mySerum.rotationtimer == 0 && mySerum.rotations32[ti * MAX_LENGTH_COLOR_ROTATION] > 0) mySerum.rotationtimer = mySerum.rotations32[ti * MAX_LENGTH_COLOR_ROTATION];
-        if (mySerum.rotationtimer == 0 && mySerum.rotations64[ti * MAX_LENGTH_COLOR_ROTATION] > 0) mySerum.rotationtimer = mySerum.rotations64[ti * MAX_LENGTH_COLOR_ROTATION];
-        if (mySerum.rotations32[ti * MAX_LENGTH_COLOR_ROTATION] > 0 && mySerum.rotations32[ti * MAX_LENGTH_COLOR_ROTATION] < mySerum.rotationtimer) mySerum.rotationtimer = mySerum.rotations32[ti * MAX_LENGTH_COLOR_ROTATION];
-        if (mySerum.rotations64[ti * MAX_LENGTH_COLOR_ROTATION] > 0 && mySerum.rotations64[ti * MAX_LENGTH_COLOR_ROTATION] < mySerum.rotationtimer) mySerum.rotationtimer = mySerum.rotations64[ti * MAX_LENGTH_COLOR_ROTATION];
-    }
-	mySerum.rotationtimer = IDENTIFY_NO_FRAME;
-	return IDENTIFY_NO_FRAME;  // no new frame, return false, client has to update rotations!
+	return IDENTIFY_NO_FRAME;  // no new frame, client has to update rotations!
 }
 
 SERUM_API uint32_t Serum_Colorize(uint8_t* frame)

--- a/src/serum-decode.h
+++ b/src/serum-decode.h
@@ -43,13 +43,6 @@ SERUM_API uint32_t Serum_Colorize(uint8_t* frame);
 */
 SERUM_API uint32_t Serum_Rotate(void);
 
-SERUM_API Serum_Frame_Struc* Serum_Load(const char* const altcolorpath, const char* const romname, uint8_t flags);
-SERUM_API void Serum_SetIgnoreUnknownFramesTimeout(uint16_t milliseconds);
-SERUM_API void Serum_SetMaximumUnknownFramesToSkip(uint8_t maximum);
-SERUM_API void Serum_SetStandardPalette(const uint8_t* palette, const int bitDepth);
-SERUM_API void Serum_Dispose(void);
-SERUM_API uint32_t Serum_Colorize(uint8_t* frame);
-SERUM_API uint32_t Serum_Rotate(void);
 SERUM_API void Serum_DisableColorization(void);
 
 SERUM_API void Serum_EnableColorization(void);

--- a/src/serum-decode.h
+++ b/src/serum-decode.h
@@ -39,7 +39,7 @@ SERUM_API uint32_t Serum_Colorize(uint8_t* frame);
 
 /** @brief Perform the color rotations of the current frame. For v1, it modifies "palette", for v2, it modifies "frame32" and/or "frame64"
 * 
-* @return The time in milliseconds before the next rotation
+* @return The time in milliseconds before the next rotation in the low word. If there was a rotation in the 32P frame, the first bit of the high word is set (0x10000) and if there was a rotation in the 64P frame, the second bit of the high word is set (0x20000)
 */
 SERUM_API uint32_t Serum_Rotate(void);
 

--- a/src/serum.h
+++ b/src/serum.h
@@ -4,8 +4,8 @@
 
 enum // returned by Serum_Load in *SerumVersion
 {
-	SERUM_V1,
-	SERUM_V2
+	SERUM_V1 = 1,
+	SERUM_V2 = 2
 };
 
 // Flags to send to Serum_Load


### PR DESCRIPTION
Since the central struct stores all states between calls to `Serum_Colorize` and `Serum_Rotate`, some code that copied lastsprites, lastrotations, etc. in case of no frame found or same frame found, is obsolete now as it only copies the same data into the struct as it is already there.

In case of same frame found, basically nothing has to be done. The client should either do nothing or keep rotating without resetting the rotation.

I didn't want to get this PR too big, but I'm convinced, that we can get rid of most of the `lastXYZ` variables.

Another issue will be fixed with this PR. In case of libdmdutil, the same instance of libserum runs endlessly and has to load new colorizations if the ROM changes. In that case, the switch between V1 and V2 colorizations was erroneous regarding the value of `mySerum.SerumVersion`.

Some functions were declared twice in serum-decode.h.