### PR TITLE
Sparse vector

### DIFF
--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -6,15 +6,13 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <unordered_map>
-#include <vector>
 #include <chrono>
 #include <filesystem>
 #include <algorithm>
 #include <optional>
-#include <type_traits>
 
 #include "serum-version.h"
+#include "sparse-vector.h"
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
@@ -54,63 +52,6 @@ const int pathbuflen = 4096;
 
 const uint32_t MAX_NUMBER_FRAMES = 0x7fffffff;
 const uint32_t IDENTIFY_SAME_FRAME = 0xfffffffe;
-
-template<typename T>
-class SparseVector {
-  static_assert(std::is_trivial<T>::value && std::is_standard_layout<T>::value,
-                "SparseVector only supports trivial types like uint8_t or uint16_t");
-
- protected:
-  std::unordered_map<uint32_t, std::vector<T>> data;
-  std::vector<T> noData;
-
- public:
-  SparseVector(T noDataSignature) {
-	noData.resize(1, noDataSignature);
-  }
-
-  // Access data for a frame (returns pointer to zeros if not found)
-  T* operator[](const uint32_t frame) {
-    auto it = data.find(frame);
-    if (it != data.end()) return it->second.data();
-    return noData.data();
-  }
-
-  // Load data (only store if non-zero)
-  void my_fread(size_t elementCount, uint32_t nframes, FILE* stream) {
-    size_t blockSize = elementCount * sizeof(T);
-
-    if (noData.size() < elementCount) noData.resize(elementCount, noData[0]);
-
-	std::vector<T> tmp(elementCount);
-
-    for (uint32_t i = 0; i < nframes; ++i) {
-      if (1 != fread(tmp.data(), blockSize, 1, stream)) {
-		// Error reading file
-		exit(1);
-	  }
-
-      if (memcmp(tmp.data(), noData.data(), noData.size() * sizeof(T)) != 0)
-        data[i] = tmp;
-    }
-  }
-
-  void set(uint32_t frame, const T* values, size_t elementCount) {
-	auto it = data.find(frame);
-	if (it != data.end()) {
-	  it->second.resize(elementCount);
-	  memcpy(it->second.data(), values, elementCount * sizeof(T));
-	} else {
-	  std::vector<T> tmp(values, values + elementCount);
-	  data[frame] = tmp;
-	}
-  }
-
-  // Clear all stored frames
-  void clear() {
-    data.clear();
-  }
-};
 
 // header
 char rname[64];

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -142,7 +142,7 @@ bool enabled = true;                             // is colorization enabled?
 bool isoriginalrequested = true; // are the original resolution frames requested by the caller
 bool isextrarequested = false; // are the extra resolution frames requested by the caller
 
-uint32_t rotationnextabsolutetime[MAX_COLOR_ROTATIONS]; // cumulative time for the next rotation for each color rotation
+uint32_t rotationnextabsolutetime[MAX_COLOR_ROTATIONS]; // cumulative time for the next rotation for each color rotation 
 
 Serum_Frame_Struc mySerum; // structure to keep communicate colorization data
 
@@ -1469,7 +1469,7 @@ uint32_t Serum_ColorizeWithMetadatav1(uint8_t* frame)
 {
 	// return IDENTIFY_NO_FRAME if no new frame detected
 	// return 0 if new frame with no rotation detected
-	// return > 0 if new frame with rotations detected, the value is the delay before the first rotation in ms
+	// return > 0 if new frame with rotations detected, the value is the delay before the first rotation in ms 
 	mySerum.triggerID = 0xffffffff;
 
 	if (!enabled)
@@ -1560,7 +1560,7 @@ SERUM_API uint32_t Serum_ColorizeWithMetadatav2(uint8_t* frame)
 {
 	// return IDENTIFY_NO_FRAME if no new frame detected
 	// return 0 if new frame with no rotation detected
-	// return > 0 if new frame with rotations detected, the value is the delay before the first rotation in ms
+	// return > 0 if new frame with rotations detected, the value is the delay before the first rotation in ms 
 	mySerum.triggerID = 0xffffffff;
 
 	// Let's first identify the incoming frame among the ones we have in the crom
@@ -1660,7 +1660,7 @@ SERUM_API uint32_t Serum_ColorizeWithMetadatav2(uint8_t* frame)
 			return (uint32_t)mySerum.rotationtimer;  // new frame, return true
 		}
 	}
-
+	
 	return IDENTIFY_NO_FRAME;  // no new frame, client has to update rotations!
 }
 

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+
 #include <chrono>
 #include <filesystem>
 #include <algorithm>

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -78,7 +78,7 @@ class SparseVectorByte {
       size_t readelem = fread(tmp, sizeElement, 1, stream);
       ac_pos_in_file += readelem * sizeElement;
       if (memcmp(tmp, zeroBufferByte, sizeElement) != 0) data[i].assign(tmp, tmp + sizeElement);
-	}
+    }
     free(tmp);
   }
 
@@ -108,7 +108,7 @@ class SparseVectorWord {
       size_t readelem = fread(tmp, sizeElement, 1, stream);
       ac_pos_in_file += readelem * sizeElement;
       if (memcmp(tmp, zeroBufferWord, sizeElement) != 0) data[i].assign(tmp, tmp + sizeElement);
-	}
+    }
     free(tmp);
   }
 

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -57,6 +57,8 @@ const uint32_t IDENTIFY_SAME_FRAME = 0xfffffffe;
 uint8_t* zeroBufferByte;
 uint16_t* zeroBufferWord;
 
+long long ac_pos_in_file;
+
 class SparseVectorByte {
  protected:
   std::unordered_map<uint32_t, std::vector<uint8_t>> data;  // Only stores non-zero data
@@ -463,7 +465,6 @@ uint32_t min(uint32_t v1, uint32_t v2)
 }
 
 long serum_file_length;
-long long ac_pos_in_file;
 FILE* fconsole;
 
 const bool IS_DEBUG_READ = false;

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -1668,7 +1668,7 @@ SERUM_API uint32_t Serum_Colorize(uint8_t* frame)
 {
 	// return IDENTIFY_NO_FRAME if no new frame detected
 	// return 0 if new frame with no rotation detected
-	// return > 0 if new frame with rotations detected, the value is the delay before the first rotation in ms
+	// return > 0 if new frame with rotations detected, the value is the delay before the first rotation in ms 
 	if (SerumVersion == SERUM_V2) return Serum_ColorizeWithMetadatav2(frame);
 	else return Serum_ColorizeWithMetadatav1(frame);
 }

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -239,7 +239,6 @@ void Serum_free(void)
 	Free_element((void**)&mySerum.rotationsinframe64);
 	Free_element((void**)&mySerum.modifiedelements32);
 	Free_element((void**)&mySerum.modifiedelements64);
-
 	cromloaded = false;
 }
 

--- a/src/serum-decode.cpp
+++ b/src/serum-decode.cpp
@@ -66,7 +66,7 @@ class SparseVector {
 
  public:
   SparseVector(T noDataSignature) {
-	noData(1, noDataSignature);
+	noData.resize(1, noDataSignature);
   }
 
   // Access data for a frame (returns pointer to zeros if not found)
@@ -90,7 +90,7 @@ class SparseVector {
 		exit(1);
 	  }
 
-      if (memcmp(tmp.data(), noData.data(), noData.size() * sizeof(T) * ) != 0)
+      if (memcmp(tmp.data(), noData.data(), noData.size() * sizeof(T)) != 0)
         data[i] = tmp;
     }
   }
@@ -166,7 +166,7 @@ SparseVector<uint8_t> backgroundmask(0);
 SparseVector<uint8_t> backgroundmaskx(0);
 uint8_t* dynashadowsdiro = NULL;
 uint16_t* dynashadowscolo = NULL;
-uint8_t* dynashadowsdirx = NULL;q
+uint8_t* dynashadowsdirx = NULL;
 uint16_t* dynashadowscolx = NULL;
 
 // variables

--- a/src/sparse-vector.h
+++ b/src/sparse-vector.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+template<typename T>
+class SparseVector
+{
+  static_assert(std::is_trivial<T>::value && std::is_standard_layout<T>::value,
+                "SparseVector only supports trivial types like uint8_t or uint16_t");
+
+ protected:
+  std::unordered_map<uint32_t, std::vector<T>> data;
+  std::vector<T> noData;
+
+ public:
+  SparseVector(T noDataSignature) {
+	noData.resize(1, noDataSignature);
+  }
+
+  // Access data for a frame (returns pointer to noData if not found)
+  T* operator[](const uint32_t frame) {
+    auto it = data.find(frame);
+    if (it != data.end()) return it->second.data();
+    return noData.data();
+  }
+
+  // Load data (only store if not matching the noData signature)
+  void my_fread(size_t elementCount, uint32_t nframes, FILE* stream) {
+    size_t blockSize = elementCount * sizeof(T);
+
+    if (noData.size() < elementCount) noData.resize(elementCount, noData[0]);
+
+	std::vector<T> tmp(elementCount);
+
+    for (uint32_t i = 0; i < nframes; ++i) {
+      if (1 != fread(tmp.data(), blockSize, 1, stream)) {
+		// Error reading file
+		exit(1);
+	  }
+
+      if (memcmp(tmp.data(), noData.data(), noData.size() * sizeof(T)) != 0)
+        data[i] = tmp;
+    }
+  }
+
+  void set(uint32_t frame, const T* values, size_t elementCount) {
+	auto it = data.find(frame);
+	if (it != data.end()) {
+	  it->second.resize(elementCount);
+	  memcpy(it->second.data(), values, elementCount * sizeof(T));
+	} else {
+	  std::vector<T> tmp(values, values + elementCount);
+	  data[frame] = tmp;
+	}
+  }
+
+  // Clear all stored frames
+  void clear() {
+    data.clear();
+  }
+};

--- a/src/sparse-vector.h
+++ b/src/sparse-vector.h
@@ -8,60 +8,72 @@
 #include <unordered_map>
 #include <vector>
 
-template<typename T>
+template <typename T>
 class SparseVector
 {
-  static_assert(std::is_trivial<T>::value && std::is_standard_layout<T>::value,
-                "SparseVector only supports trivial types like uint8_t or uint16_t");
+	static_assert(std::is_trivial<T>::value && std::is_standard_layout<T>::value,
+				  "SparseVector only supports trivial types like uint8_t or uint16_t");
 
- protected:
-  std::unordered_map<uint32_t, std::vector<T>> data;
-  std::vector<T> noData;
+protected:
+	std::unordered_map<uint32_t, std::vector<T>> data;
+	std::vector<T> noData;
 
- public:
-  SparseVector(T noDataSignature) {
-	noData.resize(1, noDataSignature);
-  }
-
-  // Access data for a frame (returns pointer to noData if not found)
-  T* operator[](const uint32_t frame) {
-    auto it = data.find(frame);
-    if (it != data.end()) return it->second.data();
-    return noData.data();
-  }
-
-  // Load data (only store if not matching the noData signature)
-  void my_fread(size_t elementCount, uint32_t nframes, FILE* stream) {
-    size_t blockSize = elementCount * sizeof(T);
-
-    if (noData.size() < elementCount) noData.resize(elementCount, noData[0]);
-
-	std::vector<T> tmp(elementCount);
-
-    for (uint32_t i = 0; i < nframes; ++i) {
-      if (1 != fread(tmp.data(), blockSize, 1, stream)) {
-		// Error reading file
-		exit(1);
-	  }
-
-      if (memcmp(tmp.data(), noData.data(), noData.size() * sizeof(T)) != 0)
-        data[i] = tmp;
-    }
-  }
-
-  void set(uint32_t frame, const T* values, size_t elementCount) {
-	auto it = data.find(frame);
-	if (it != data.end()) {
-	  it->second.resize(elementCount);
-	  memcpy(it->second.data(), values, elementCount * sizeof(T));
-	} else {
-	  std::vector<T> tmp(values, values + elementCount);
-	  data[frame] = tmp;
+public:
+	SparseVector(T noDataSignature)
+	{
+		noData.resize(1, noDataSignature);
 	}
-  }
 
-  // Clear all stored frames
-  void clear() {
-    data.clear();
-  }
+	// Access data for a frame (returns pointer to noData if not found)
+	T *operator[](const uint32_t frame)
+	{
+		auto it = data.find(frame);
+		if (it != data.end())
+			return it->second.data();
+		return noData.data();
+	}
+
+	// Load data (only store if not matching the noData signature)
+	void my_fread(size_t elementCount, uint32_t nframes, FILE *stream)
+	{
+		size_t blockSize = elementCount * sizeof(T);
+
+		if (noData.size() < elementCount)
+			noData.resize(elementCount, noData[0]);
+
+		std::vector<T> tmp(elementCount);
+
+		for (uint32_t i = 0; i < nframes; ++i)
+		{
+			if (1 != fread(tmp.data(), blockSize, 1, stream))
+			{
+				// Error reading file
+				exit(1);
+			}
+
+			if (memcmp(tmp.data(), noData.data(), noData.size() * sizeof(T)) != 0)
+				data[i] = tmp;
+		}
+	}
+
+	void set(uint32_t frame, const T *values, size_t elementCount)
+	{
+		auto it = data.find(frame);
+		if (it != data.end())
+		{
+			it->second.resize(elementCount);
+			memcpy(it->second.data(), values, elementCount * sizeof(T));
+		}
+		else
+		{
+			std::vector<T> tmp(values, values + elementCount);
+			data[frame] = tmp;
+		}
+	}
+
+	// Clear all stored frames
+	void clear()
+	{
+		data.clear();
+	}
 };


### PR DESCRIPTION
@zesinger @jsm174 @vbousquet I reviewed the code of libserum and noticed that it reserves a lot of memory which isn't really used:
```c++
    dynamasks = (uint8_t*)malloc(nframes * fwidth * fheight);
    dynamasksx = (uint8_t*)malloc(nframes * fwidthx * fheightx);
    dyna4colsn = (uint16_t*)malloc(nframes * MAX_DYNA_SETS_PER_FRAMEN * nocolors * sizeof(uint16_t));
    dyna4colsnx = (uint16_t*)malloc(nframes * MAX_DYNA_SETS_PER_FRAMEN * nocolors * sizeof(uint16_t));
    framesprites = (uint8_t*)malloc(nframes * MAX_SPRITES_PER_FRAME);
    framespriteBB = (uint16_t*)malloc(nframes * MAX_SPRITES_PER_FRAME * 4 * sizeof(uint16_t));    
    colorrotationsn = (uint16_t*)malloc(nframes * MAX_LENGTH_COLOR_ROTATION * MAX_COLOR_ROTATIONN * sizeof(uint16_t));
    colorrotationsnx = (uint16_t*)malloc(nframes * MAX_LENGTH_COLOR_ROTATION * MAX_COLOR_ROTATIONN * sizeof(uint16_t));
    triggerIDs = (uint32_t*)malloc(nframes * sizeof(uint32_t));
    backgroundIDs = (uint16_t*)malloc(nframes * sizeof(uint16_t));
    backgroundmask = (uint8_t*)malloc(nframes * fwidth * fheight);
    backgroundmaskx = (uint8_t*)malloc(nframes * fwidthx * fheightx);
    dynashadowsdiro = (uint8_t*)malloc(nframes * MAX_DYNA_SETS_PER_FRAMEN);
    dynashadowscolo = (uint16_t*)malloc(nframes * MAX_DYNA_SETS_PER_FRAMEN * sizeof(uint16_t));
    dynashadowsdirx = (uint8_t*)malloc(nframes * MAX_DYNA_SETS_PER_FRAMEN);
    dynashadowscolx = (uint16_t*)malloc(nframes * MAX_DYNA_SETS_PER_FRAMEN * sizeof(uint16_t));
```

Basically the memory for dynamic masks, background masks, sprites, etc gets reserved per frame, regardless if a particular frame uses that feature or not.
For sure that is the fastest implementation and it works.
After a conversation with @zesinger I came up with the idea to not use memory if the data reflects the default value. In most cases that is a set of zeros.

This PR contains the conversion of `colorrotationsn`and `colorrotationsnx` to that approach as an example. Depending on your thoughts, we could convert all of the pointers above in "sparse vectors".

My intention is to reduce the memory usage without chnaging the serum file format and without changes to the colorization editor. And the code itself should require as few changes as possible.